### PR TITLE
TYPO3 12 compatibility

### DIFF
--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -105,11 +105,9 @@ Options:
                 - mysqli (default)
                 - pdo_mysql
 
-    -p <7.2|7.3|7.4|8.0|8.1|8.2>
+    -p <7.4|8.0|8.1|8.2>
         Specifies the PHP minor version to be used
-            - 7.2: (default): use PHP 7.2
-            - 7.3: use PHP 7.3
-            - 7.4: use PHP 7.4
+            - 7.4: (default): use PHP 7.4
             - 8.0: use PHP 8.0
             - 8.0: use PHP 8.1
             - 8.0: use PHP 8.2
@@ -169,8 +167,8 @@ cd ../testing-docker || exit 1
 ROOT_DIR=$(readlink -f ${PWD}/../../)
 TEST_SUITE="unit"
 DBMS="sqlite"
-PHP_VERSION="7.2"
-TYPO3_VERSION="10"
+PHP_VERSION="7.4"
+TYPO3_VERSION="11"
 PHP_XDEBUG_ON=0
 PHP_XDEBUG_PORT=9003
 EXTRA_TEST_OPTIONS=""

--- a/Classes/Domain/Repository/FileRepository.php
+++ b/Classes/Domain/Repository/FileRepository.php
@@ -181,7 +181,7 @@ class FileRepository implements SingletonInterface
                 )
             )
             ->execute();
-        $refIndexCount = (int)$res1->fetchColumn(0);
+        $refIndexCount = (int)$res1->fetchOne();
 
         // sys_file_reference
         $queryBuilder2 = $this->connection->getQueryBuilderForTable('sys_file_reference');
@@ -199,7 +199,7 @@ class FileRepository implements SingletonInterface
                 ),
             )
             ->execute();
-        $fileReferenceCount = (int)$res2->fetchColumn(0);
+        $fileReferenceCount = (int)$res2->fetchOne();
 
         return max($refIndexCount, $fileReferenceCount);
     }

--- a/Classes/FileFacade.php
+++ b/Classes/FileFacade.php
@@ -255,6 +255,7 @@ class FileFacade
 
         if (!isset(self::$lastReferenceTimestamps[$uid])) {
             self::$lastReferenceTimestamps[$uid] = 0;
+            $row = null;
 
             if ($this->queryBuilder) {
                 $queryBuilder = $this->queryBuilder->getQueryBuilderForTable('sys_file_reference');

--- a/Configuration/Backend/Modules.php
+++ b/Configuration/Backend/Modules.php
@@ -1,0 +1,16 @@
+<?php
+
+return [
+    'file_WvFileCleanupCleanup' => [
+        'parent' => 'file',
+        'access' => 'user,group',
+        'workspaces' => 'online,custom',
+        'path' => '/file/wvfilecleanup',
+        'icon' => 'EXT:wv_file_cleanup/Resources/Public/Icons/module-cleanup.svg',
+        'labels' => 'LLL:EXT:wv_file_cleanup/Resources/Private/Language/locallang_mod_cleanup.xlf',
+        'extensionName' => 'wv_file_cleanup',
+        'controllerActions' => [
+            \WebVision\WvFileCleanup\Controller\CleanupController::class => ['index', 'cleanup'],
+        ],
+    ],
+];

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -24,3 +24,7 @@ services:
       - name: event.listener
         method: 'postFileMove'
         event:  TYPO3\CMS\Core\Resource\Event\AfterFileMovedEvent
+
+  WebVision\WvFileCleanup\Controller\CleanupController:
+    tags: [ 'backend.controller' ]
+

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "license": ["GPL-3.0+"],
     "require": {
 		"php": ">=7.4 || >= 8.0",
-        "typo3/cms-core": "^10.4 || ^11.5"
+        "typo3/cms-core": "^11.5"
     },
     "require-dev": {
         "typo3/testing-framework": "^6.16",

--- a/composer.json
+++ b/composer.json
@@ -6,10 +6,10 @@
     "license": ["GPL-3.0+"],
     "require": {
 		"php": ">=7.4 || >= 8.0",
-        "typo3/cms-core": "^11.5"
+        "typo3/cms-core": "^11.5 || ^12.4"
     },
     "require-dev": {
-        "typo3/testing-framework": "^6.16",
+        "typo3/testing-framework": "^6.16 || ^7.0",
         "saschaegerer/phpstan-typo3": "^1.8",
         "phpstan/phpstan": "^1.10",
         "friendsofphp/php-cs-fixer": "^v3.0"

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -11,7 +11,7 @@ $EM_CONF[$_EXTKEY] = [
     'author_company' => 'beech.it, web-vision GmbH',
     'constraints' => [
         'depends' => [
-            'typo3' => '10.4.1-11.5.99',
+            'typo3' => '11.5.1-12.4.99',
         ],
     ],
 ];

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -1,3 +1,3 @@
 <?php
 
-defined('TYPO3_MODE') || die();
+defined('TYPO3') || die();

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -1,19 +1,21 @@
 <?php
 
-defined('TYPO3_MODE') || die();
+defined('TYPO3') || die();
 
-\TYPO3\CMS\Extbase\Utility\ExtensionUtility::registerModule(
-    'WebVision.WvFileCleanup',
-    'file',
-    'cleanup',
-    '',
-    [
-        \WebVision\WvFileCleanup\Controller\CleanupController::class => 'index, cleanup',
-    ],
-    [
-        'access' => 'user,group',
-        'workspaces' => 'online,custom',
-        'icon' => 'EXT:wv_file_cleanup/Resources/Public/Icons/module-cleanup.svg',
-        'labels' => 'LLL:EXT:wv_file_cleanup/Resources/Private/Language/locallang_mod_cleanup.xlf',
-    ]
-);
+if ((new \TYPO3\CMS\Core\Information\Typo3Version())->getMajorVersion() < 12) {
+    \TYPO3\CMS\Extbase\Utility\ExtensionUtility::registerModule(
+        'WebVision.WvFileCleanup',
+        'file',
+        'cleanup',
+        '',
+        [
+            \WebVision\WvFileCleanup\Controller\CleanupController::class => 'index, cleanup',
+        ],
+        [
+            'access' => 'user,group',
+            'workspaces' => 'online,custom',
+            'icon' => 'EXT:wv_file_cleanup/Resources/Public/Icons/module-cleanup.svg',
+            'labels' => 'LLL:EXT:wv_file_cleanup/Resources/Private/Language/locallang_mod_cleanup.xlf',
+        ]
+    );
+}


### PR DESCRIPTION
I haven't seen any information about TYPO3 12 compatibility but I needed a working version really soon. So I decided to do it myself as it wasn't that much to do. I think the only thing that does not work in 12 like in 11 is the onclick event for the doc header buttons when you are not in the root level. Going one level up works though but not the additional event.
And I got to admit that I didn't test the extension in a production setup yet. So there might be still some problems.

I based the changes on the code-updates branch.