### PR TITLE
[TASK] Use new internal `FileFacadeFactory` in `FileRepository`

### DIFF
--- a/Build/phpstan/core11/phpstan-baseline.neon
+++ b/Build/phpstan/core11/phpstan-baseline.neon
@@ -106,11 +106,6 @@ parameters:
 			path: ../../../Classes/Domain/Repository/FileRepository.php
 
 		-
-			message: "#^Access to an undefined property WebVision\\\\WvFileCleanup\\\\FileFacade\\:\\:\\$iconFactory\\.$#"
-			count: 2
-			path: ../../../Classes/FileFacade.php
-
-		-
 			message: "#^Cannot call method fetchAllAssociative\\(\\) on Doctrine\\\\DBAL\\\\Result\\|int\\.$#"
 			count: 1
 			path: ../../../Classes/FileFacade.php

--- a/Build/phpstan/core12/phpstan-baseline.neon
+++ b/Build/phpstan/core12/phpstan-baseline.neon
@@ -116,11 +116,6 @@ parameters:
 			path: ../../../Classes/Domain/Repository/FileRepository.php
 
 		-
-			message: "#^Access to an undefined property WebVision\\\\WvFileCleanup\\\\FileFacade\\:\\:\\$iconFactory\\.$#"
-			count: 2
-			path: ../../../Classes/FileFacade.php
-
-		-
 			message: "#^Cannot call method fetchAllAssociative\\(\\) on Doctrine\\\\DBAL\\\\Result\\|int\\.$#"
 			count: 1
 			path: ../../../Classes/FileFacade.php

--- a/Classes/Domain/Repository/FileRepository.php
+++ b/Classes/Domain/Repository/FileRepository.php
@@ -15,10 +15,13 @@ use TYPO3\CMS\Core\Resource\ProcessedFile;
 use TYPO3\CMS\Core\SingletonInterface;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use WebVision\WvFileCleanup\FileFacade;
+use WebVision\WvFileCleanup\FileFacadeFactory;
 use WebVision\WvFileCleanup\Service\FileCollectionService;
 
 /**
- * Class FileRepository
+ * Provide FileList related methods.
+ *
+ * @internal and not part of public API.
  */
 class FileRepository implements SingletonInterface
 {
@@ -42,6 +45,8 @@ class FileRepository implements SingletonInterface
      */
     protected $fileCollectionService;
 
+    protected FileFacadeFactory $fileFacadeFactory;
+
     /**
      * @throws ExtensionConfigurationExtensionNotConfiguredException
      * @throws ExtensionConfigurationPathDoesNotExistException
@@ -50,6 +55,7 @@ class FileRepository implements SingletonInterface
     {
         $this->connection = GeneralUtility::makeInstance(ConnectionPool::class);
         $this->fileCollectionService = GeneralUtility::makeInstance(FileCollectionService::class);
+        $this->fileFacadeFactory = GeneralUtility::makeInstance(FileFacadeFactory::class);
         $this->fileNameDenyPattern = GeneralUtility::makeInstance(ExtensionConfiguration::class)
             ->get('wv_file_cleanup', 'fileNameDenyPattern');
         $this->pathDenyPattern = GeneralUtility::makeInstance(ExtensionConfiguration::class)
@@ -104,7 +110,9 @@ class FileRepository implements SingletonInterface
         });
 
         foreach ($files as $file) {
-            $return[] = new FileFacade($file);
+            if ($file instanceof FileInterface) {
+                $return[] = $this->fileFacadeFactory->forFileInterface($file);
+            }
         }
 
         return $return;

--- a/Classes/FileFacadeFactory.php
+++ b/Classes/FileFacadeFactory.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WebVision\WvFileCleanup;
+
+use TYPO3\CMS\Core\Imaging\Icon;
+use TYPO3\CMS\Core\Imaging\IconFactory;
+use TYPO3\CMS\Core\Resource\FileInterface;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use WebVision\WvFileCleanup\Domain\Repository\FileRepository;
+
+/**
+ * Provide factory to create FileFacade instances and to be used only in {@see FileRepository}.
+ *
+ * @internal and not part of public API.
+ */
+final class FileFacadeFactory
+{
+    private IconFactory $iconFactory;
+
+    public function __construct(
+        IconFactory $iconFactory
+    ) {
+        $this->iconFactory = $iconFactory;
+    }
+
+    /**
+     * Create new not shared FileFacade instance for `$file`.
+     */
+    public function forFileInterface(FileInterface $file): FileFacade
+    {
+        return GeneralUtility::makeInstance(
+            FileFacade::class,
+            $file,
+            $this->iconFactory->getIconForResource($file, Icon::SIZE_SMALL)
+        );
+    }
+}

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -6,6 +6,8 @@ services:
 
   WebVision\WvFileCleanup\:
     resource: '../Classes/*'
+    exclude:
+      - '../Classes/FileFacade.php'
 
   WebVision\WvFileCleanup\Command\EmptyRecyclerCommand:
     tags:
@@ -27,3 +29,6 @@ services:
 
   WebVision\WvFileCleanup\Controller\CleanupController:
     tags: [ 'backend.controller' ]
+
+  WebVision\WvFileCleanup\FileFacadeFactory:
+    public: true


### PR DESCRIPTION
This change introduces the new internal service `FileFacadeFactory`
to create DTO `FileFacade` instances for file resources and ensure
that required relation data is properly set, for example passing
the corresponding icon along with the file resource to the class
constructor and avoid introducing new service like features to
the DTO like `FileFacede`.

Internal methods using the `IconFactory` are adopted to use the
`Icon` instance passed by the constructor and the `IconFactory`
service is removed from `FileFacade`.

Other service like properties seems to be unused and not initalized
and `@todo` markers are added to investigate this later if it can
be safely removed/dropped or moved to proper places.

Used command(s):

```shell
Build/Scripts/runTests.sh -p 7.4 -t 11 -s composerUpdate && \
Build/Scripts/runTests.sh -p 7.4 -t 11 -s phpstanGenerateBaseline && \
Build/Scripts/runTests.sh -p 8.1 -t 12 -s composerUpdate && \
Build/Scripts/runTests.sh -p 8.1 -t 12 -s phpstanGenerateBaseline
```