### PR TITLE
[BUGFIX] Add missing class property

### DIFF
--- a/Classes/FileFacade.php
+++ b/Classes/FileFacade.php
@@ -53,6 +53,8 @@ class FileFacade
      */
     protected $databaseConnection;
 
+    protected IconFactory $iconFactory;
+
     /**
      * @param \TYPO3\CMS\Core\Resource\FileInterface $resource
      */


### PR DESCRIPTION
A property was missing, to avoid exception
```
PHP Runtime Deprecation Notice: Creation of dynamic property WebVision\WvFileCleanup\FileFacade::$iconFactory is deprecated in /var/www/
  html/app/site/vendor/web-vision/wv_file_cleanup/Classes/FileFacade.php line 64
```

Resolves: #23 