### PR TITLE
[TASK] T3C-237: Use correct indentation and chars in `composer.json`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,9 @@
     "type": "typo3-cms-extension",
     "description": "Enables cleanup of unused fal records.",
     "homepage": "https://web-vision.de",
-    "license": ["GPL-3.0+"],
+    "license": [
+        "GPL-3.0+"
+    ],
     "require": {
         "php": "^7.4 || ^8.0 || ^8.1 || ^8.2 || ^8.3 || ^8.4 || ^8.5",
         "typo3/cms-backend": "^11.5@dev || ^12.4@dev",
@@ -34,11 +36,11 @@
             "WebVision\\WvFileCleanup\\": "Classes"
         }
     },
-	"autoload-dev": {
-		"psr-4": {
-			"WebVision\\WvFileCleanup\\Tests\\": "Tests"
-		}
-	},
+    "autoload-dev": {
+        "psr-4": {
+            "WebVision\\WvFileCleanup\\Tests\\": "Tests"
+        }
+    },
     "extra": {
         "typo3/cms": {
             "extension-key": "wv_file_cleanup",


### PR DESCRIPTION
This change streamlines the root `composer.json` to use the
expected indentation of 4 space chares for each level ending
in a more readable file.

Used command(s):

```shell
cat <<< $(
  jq --indent 4 '.' composer.json
) > composer.json
```