### PR TITLE
[TASK] Add first unit tests and enable pipelines

### DIFF
--- a/.github/workflows/core-11.yml
+++ b/.github/workflows/core-11.yml
@@ -123,3 +123,95 @@ jobs:
 
       - name: "Run PHP lint"
         run: "Build/Scripts/runTests.sh -t ${{ matrix.typo3 }} -p ${{ matrix.php-version }} -s lintPhp"
+
+  unit:
+    name: "unit"
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php-version: [ "7.4", "8.0", "8.1", "8.2", "8.3", "8.4" ]
+        typo3: ["11"]
+    permissions:
+      # actions: read|write|none
+      actions: none
+      # checks: read|write|none
+      checks: none
+      # contents: read|write|none
+      contents: read
+      # deployments: read|write|none
+      deployments: none
+      # id-token: read|write|none
+      id-token: none
+      # issues: read|write|none
+      issues: none
+      # discussions: read|write|none
+      discussions: none
+      # packages: read|write|none
+      packages: read
+      # pages: read|write|none
+      pages: none
+      # pull-requests: read|write|none
+      pull-requests: none
+      # repository-projects: read|write|none
+      repository-projects: read
+      # security-events: read|write|none
+      security-events: none
+      # statuses: read|write|none
+      statuses: none
+    steps:
+
+      - name: "Checkout"
+        uses: actions/checkout@v4
+
+      - name: "Prepare dependencies for TYPO3 v${{ matrix.typo3 }}"
+        run: "Build/Scripts/runTests.sh -t ${{ matrix.typo3 }} -p ${{ matrix.php-version }} -s composerUpdate"
+
+      - name: "Executing tests"
+        run: "Build/Scripts/runTests.sh -t ${{ matrix.typo3 }} -p ${{ matrix.php-version }} -s unit"
+
+  unitRandom:
+    name: "unitRandom"
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php-version: [ "7.4", "8.0", "8.1", "8.2", "8.3", "8.4" ]
+        typo3: ["11"]
+    permissions:
+      # actions: read|write|none
+      actions: none
+      # checks: read|write|none
+      checks: none
+      # contents: read|write|none
+      contents: read
+      # deployments: read|write|none
+      deployments: none
+      # id-token: read|write|none
+      id-token: none
+      # issues: read|write|none
+      issues: none
+      # discussions: read|write|none
+      discussions: none
+      # packages: read|write|none
+      packages: read
+      # pages: read|write|none
+      pages: none
+      # pull-requests: read|write|none
+      pull-requests: none
+      # repository-projects: read|write|none
+      repository-projects: read
+      # security-events: read|write|none
+      security-events: none
+      # statuses: read|write|none
+      statuses: none
+    steps:
+
+      - name: "Checkout"
+        uses: actions/checkout@v4
+
+      - name: "Prepare dependencies for TYPO3 v${{ matrix.typo3 }}"
+        run: "Build/Scripts/runTests.sh -t ${{ matrix.typo3 }} -p ${{ matrix.php-version }} -s composerUpdate"
+
+      - name: "Executing tests"
+        run: "Build/Scripts/runTests.sh -t ${{ matrix.typo3 }} -p ${{ matrix.php-version }} -s unitRandom"

--- a/.github/workflows/core-12.yml
+++ b/.github/workflows/core-12.yml
@@ -123,3 +123,95 @@ jobs:
 
       - name: "Run PHP lint"
         run: "Build/Scripts/runTests.sh -t ${{ matrix.typo3 }} -p ${{ matrix.php-version }} -s lintPhp"
+
+  unit:
+    name: "unit"
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php-version: [ "8.1", "8.2", "8.3", "8.4" ]
+        typo3: ["12"]
+    permissions:
+      # actions: read|write|none
+      actions: none
+      # checks: read|write|none
+      checks: none
+      # contents: read|write|none
+      contents: read
+      # deployments: read|write|none
+      deployments: none
+      # id-token: read|write|none
+      id-token: none
+      # issues: read|write|none
+      issues: none
+      # discussions: read|write|none
+      discussions: none
+      # packages: read|write|none
+      packages: read
+      # pages: read|write|none
+      pages: none
+      # pull-requests: read|write|none
+      pull-requests: none
+      # repository-projects: read|write|none
+      repository-projects: read
+      # security-events: read|write|none
+      security-events: none
+      # statuses: read|write|none
+      statuses: none
+    steps:
+
+      - name: "Checkout"
+        uses: actions/checkout@v4
+
+      - name: "Prepare dependencies for TYPO3 v${{ matrix.typo3 }}"
+        run: "Build/Scripts/runTests.sh -t ${{ matrix.typo3 }} -p ${{ matrix.php-version }} -s composerUpdate"
+
+      - name: "Executing tests"
+        run: "Build/Scripts/runTests.sh -t ${{ matrix.typo3 }} -p ${{ matrix.php-version }} -s unit"
+
+  unitRandom:
+    name: "unitRandom"
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php-version: [ "8.1", "8.2", "8.3", "8.4" ]
+        typo3: ["12"]
+    permissions:
+      # actions: read|write|none
+      actions: none
+      # checks: read|write|none
+      checks: none
+      # contents: read|write|none
+      contents: read
+      # deployments: read|write|none
+      deployments: none
+      # id-token: read|write|none
+      id-token: none
+      # issues: read|write|none
+      issues: none
+      # discussions: read|write|none
+      discussions: none
+      # packages: read|write|none
+      packages: read
+      # pages: read|write|none
+      pages: none
+      # pull-requests: read|write|none
+      pull-requests: none
+      # repository-projects: read|write|none
+      repository-projects: read
+      # security-events: read|write|none
+      security-events: none
+      # statuses: read|write|none
+      statuses: none
+    steps:
+
+      - name: "Checkout"
+        uses: actions/checkout@v4
+
+      - name: "Prepare dependencies for TYPO3 v${{ matrix.typo3 }}"
+        run: "Build/Scripts/runTests.sh -t ${{ matrix.typo3 }} -p ${{ matrix.php-version }} -s composerUpdate"
+
+      - name: "Executing tests"
+        run: "Build/Scripts/runTests.sh -t ${{ matrix.typo3 }} -p ${{ matrix.php-version }} -s unitRandom"

--- a/Tests/Unit/VersionTest.php
+++ b/Tests/Unit/VersionTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WebVision\WvFileCleanup\Tests\Unit;
+
+use TYPO3\CMS\Core\Information\Typo3Version;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+/**
+ * @internal
+ */
+final class VersionTest extends UnitTestCase
+{
+    public static function core11DataSets(): \Generator
+    {
+        $t3v = new Typo3Version();
+        yield 'major version is 11' => [
+            'label' => 'major version is 11',
+            'expected' => 11,
+            'value' => $t3v->getMajorVersion(),
+        ];
+        yield 'branch is 11.5' => [
+            'label' => 'branch is 11.5',
+            'expected' => '11.5',
+            'value' => $t3v->getBranch(),
+        ];
+        yield 'version is greater or equal than 11.5.0' => [
+            'label' => 'version is greater or equal than 11.5.0',
+            'expected' => true,
+            'value' => version_compare($t3v->getVersion(), '11.5.0', '>='),
+        ];
+        yield 'version is lower than 11.6.0' => [
+            'label' => 'version is lower than 11.6.0',
+            'expected' => true,
+            'value' => version_compare($t3v->getVersion(), '11.6.0', '<'),
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider core11DataSets
+     * @group not-core-12
+     *
+     * @param int|string|bool $expected
+     * @param int|string|bool $value
+     */
+    public function verifyVersionForCore11(string $label, $expected, $value): void
+    {
+        $this->assertSame($expected, $value, $label);
+    }
+
+    public static function core12DataSets(): \Generator
+    {
+        $t3v = new Typo3Version();
+        yield 'major version is 12' => [
+            'label' => 'major version is 12',
+            'expected' => 12,
+            'value' => $t3v->getMajorVersion(),
+        ];
+        yield 'branch is 12.4' => [
+            'label' => 'branch is 12.4',
+            'expected' => '12.4',
+            'value' => $t3v->getBranch(),
+        ];
+        yield 'version is greater or equal than 12.4.0' => [
+            'label' => 'version is greater or equal than 12.4.0',
+            'expected' => true,
+            'value' => version_compare($t3v->getVersion(), '12.4.0', '>='),
+        ];
+        yield 'version is lower than 12.5.0' => [
+            'label' => 'version is lower than 12.5.0',
+            'expected' => true,
+            'value' => version_compare($t3v->getVersion(), '12.5.0', '<'),
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider core12DataSets
+     * @group not-core-11
+     *
+     * @param int|string|bool $expected
+     * @param int|string|bool $value
+     */
+    public function verifyVersionForCore12(string $label, $expected, $value): void
+    {
+        $this->assertSame($expected, $value, $label);
+    }
+}


### PR DESCRIPTION
This changes adds TYPO3 version tests as unit tests
to provide baseline tests and also tests the version
exclude groups introduced with a recent change.

* Implement `VersonTest` unit test.
* Enable `unit` and `unitRandom` execution within the
  Github Action workflows to execute them now for all
  pull-requests.

Used command(s):

```bash
Build/Scripts/runTests.sh -p 7.4 -t 11 -s composerUpdate \
&& Build/Scripts/runTests.sh -p 7.4 -t 11 -s cgl
```
