### PR TITLE
[BUGFIX] Don't pass vendor name as part of `$extensionName`

### DIFF
--- a/ext_tables.php
+++ b/ext_tables.php
@@ -2,9 +2,14 @@
 
 defined('TYPO3') || die();
 
+// @todo Remove complete if block when TYPO3 v11 support is dropped. Since TYPO3 v12 this is provided with the
+//       `Configuration/Backend/Modules.php` file as part of the new backend module routing and registration.
+//       See: https://review.typo3.org/c/Packages/TYPO3.CMS/+/73058
+//       See: https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/12.0/Breaking-96733-RemovedSupportForModuleHandlingBasedOnTBE_MODULES.html
+//       See: https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/12.0/Feature-96733-NewBackendModuleRegistrationAPI.html
 if ((new \TYPO3\CMS\Core\Information\Typo3Version())->getMajorVersion() < 12) {
     \TYPO3\CMS\Extbase\Utility\ExtensionUtility::registerModule(
-        'WebVision.WvFileCleanup',
+        'WvFileCleanup',
         'file',
         'cleanup',
         '',


### PR DESCRIPTION
TYPO3 v10 changed extbase plugin controller registration from non-namespaced
to namespaced variant depreacting the old way, which also included emitting
in `TYPO3\CMS\Extbase\Utility\ExtensionUtility::registerModule()` a custom
`E_USER_DEPREATED` error when passing `$extensionName` containing the vendor
name.

Following core principles tests should be as hard as possible and therefore
taking deprecations as breaking, which change modifies the calling places to
avoid these messages and preparing to introduce functional tests to increase
the quality of the extension over time.

Additionally, the v11 conditional block in `ext_tables.php` is enriched with
comments what to do when v11 support is dropped along with links to further
readups in the TYPO3 documentation.

[1] https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/10.0/Deprecation-87550-UseControllerClassesWhenRegisteringPluginsmodules.html
[2] https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/11.0/Breaking-92609-UseControllerClassesWhenRegisteringPluginsmodules.html
