### PR TITLE
[TASK] Add first functional test and enable pipelines

### DIFF
--- a/.github/workflows/core-11.yml
+++ b/.github/workflows/core-11.yml
@@ -127,10 +127,13 @@ jobs:
   unit:
     name: "unit"
     runs-on: ubuntu-latest
+    needs: ["code-quality", "linting", "integration"]
     strategy:
       fail-fast: false
       matrix:
-        php-version: [ "7.4", "8.0", "8.1", "8.2", "8.3", "8.4" ]
+        # Only test with lowest and highest supported php version to reduce count of test mutations. Highest should
+        # reveal issues with php version in-between in most of the cases.
+        php-version: [ "7.4", "8.4" ]
         typo3: ["11"]
     permissions:
       # actions: read|write|none
@@ -173,10 +176,13 @@ jobs:
   unitRandom:
     name: "unitRandom"
     runs-on: ubuntu-latest
+    needs: ["code-quality", "linting", "integration"]
     strategy:
       fail-fast: false
       matrix:
-        php-version: [ "7.4", "8.0", "8.1", "8.2", "8.3", "8.4" ]
+        # Only test with lowest and highest supported php version to reduce count of test mutations. Highest should
+        # reveal issues with php version in-between in most of the cases.
+        php-version: [ "7.4", "8.4" ]
         typo3: ["11"]
     permissions:
       # actions: read|write|none
@@ -215,3 +221,70 @@ jobs:
 
       - name: "Executing tests"
         run: "Build/Scripts/runTests.sh -t ${{ matrix.typo3 }} -p ${{ matrix.php-version }} -s unitRandom"
+
+  functional:
+    name: "functional"
+    # ubuntu-latest the available podman version seems to have issues with MariaDB images 10.4 or higher.
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        # Only test with lowest and highest supported php version to reduce count of test mutations. Highest should
+        # reveal issues with php version in-between in most of the cases.
+        php-version: [ "7.4", "8.4" ]
+        typo3: ["11"]
+    needs: ["code-quality", "linting", "integration"]
+    permissions:
+      # actions: read|write|none
+      actions: none
+      # checks: read|write|none
+      checks: none
+      # contents: read|write|none
+      contents: read
+      # deployments: read|write|none
+      deployments: none
+      # id-token: read|write|none
+      id-token: none
+      # issues: read|write|none
+      issues: none
+      # discussions: read|write|none
+      discussions: none
+      # packages: read|write|none
+      packages: read
+      # pages: read|write|none
+      pages: none
+      # pull-requests: read|write|none
+      pull-requests: none
+      # repository-projects: read|write|none
+      repository-projects: read
+      # security-events: read|write|none
+      security-events: none
+      # statuses: read|write|none
+      statuses: none
+    steps:
+
+      - name: "Checkout"
+        uses: actions/checkout@v4
+
+      - name: "Prepare dependencies for TYPO3 v${{ matrix.typo3 }}"
+        run: "Build/Scripts/runTests.sh -t ${{ matrix.typo3 }} -p ${{ matrix.php-version }} -s composerUpdate"
+
+      - name: "functional with SQLite"
+        run: "Build/Scripts/runTests.sh -t ${{ matrix.typo3 }} -p ${{ matrix.php-version }} -d sqlite -s functional"
+
+      - name: "functional with MySQL 5.5 mysqli"
+        run: "Build/Scripts/runTests.sh -t ${{ matrix.typo3 }} -p ${{ matrix.php-version }} -d mysql -i 5.5 -a mysqli -s functional"
+
+      - name: "functional with MySQL 8.0 pdo_mysql"
+        run: "Build/Scripts/runTests.sh -t ${{ matrix.typo3 }} -p ${{ matrix.php-version }} -d mysql -i 8.0 -a pdo_mysql -s functional"
+
+      - name: "functional with MariaDB 10.4 mysqli"
+        run: "Build/Scripts/runTests.sh -t ${{ matrix.typo3 }} -p ${{ matrix.php-version }} -d mariadb -i 10.4 -a mysqli -s functional"
+
+      - name: "functional with MariaDB 10.6 pdo_mysql"
+        run: "Build/Scripts/runTests.sh -t ${{ matrix.typo3 }} -p ${{ matrix.php-version }} -d mariadb -i 10.6 -a pdo_mysql -s functional"
+
+      - name: "functional with Postgres 10"
+        # Would require composer patch for dbal 2.x with PHP8.1 or newer
+        if: ${{ matrix.php-version >= '8.1' }}
+        run: "Build/Scripts/runTests.sh -t ${{ matrix.typo3 }} -p ${{ matrix.php-version }} -d postgres -i 10 -s functional"

--- a/.github/workflows/core-12.yml
+++ b/.github/workflows/core-12.yml
@@ -127,10 +127,13 @@ jobs:
   unit:
     name: "unit"
     runs-on: ubuntu-latest
+    needs: ["code-quality", "linting", "integration"]
     strategy:
       fail-fast: false
       matrix:
-        php-version: [ "8.1", "8.2", "8.3", "8.4" ]
+        # Only test with lowest and highest supported php version to reduce count of test mutations. Highest should
+        # reveal issues with php version in-between in most of the cases.
+        php-version: [ "8.1", "8.4" ]
         typo3: ["12"]
     permissions:
       # actions: read|write|none
@@ -173,10 +176,13 @@ jobs:
   unitRandom:
     name: "unitRandom"
     runs-on: ubuntu-latest
+    needs: ["code-quality", "linting", "integration"]
     strategy:
       fail-fast: false
       matrix:
-        php-version: [ "8.1", "8.2", "8.3", "8.4" ]
+        # Only test with lowest and highest supported php version to reduce count of test mutations. Highest should
+        # reveal issues with php version in-between in most of the cases.
+        php-version: [ "8.1", "8.4" ]
         typo3: ["12"]
     permissions:
       # actions: read|write|none
@@ -215,3 +221,69 @@ jobs:
 
       - name: "Executing tests"
         run: "Build/Scripts/runTests.sh -t ${{ matrix.typo3 }} -p ${{ matrix.php-version }} -s unitRandom"
+
+
+  functional:
+    name: "functional"
+    # ubuntu-latest the available podman version seems to have issues with MariaDB images 10.4 or higher.
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        # Only test with lowest and highest supported php version to reduce count of test mutations. Highest should
+        # reveal issues with php version in-between in most of the cases.
+        php-version: [ "8.1", "8.4" ]
+        typo3: ["12"]
+    needs: ["code-quality", "linting", "integration"]
+    permissions:
+      # actions: read|write|none
+      actions: none
+      # checks: read|write|none
+      checks: none
+      # contents: read|write|none
+      contents: read
+      # deployments: read|write|none
+      deployments: none
+      # id-token: read|write|none
+      id-token: none
+      # issues: read|write|none
+      issues: none
+      # discussions: read|write|none
+      discussions: none
+      # packages: read|write|none
+      packages: read
+      # pages: read|write|none
+      pages: none
+      # pull-requests: read|write|none
+      pull-requests: none
+      # repository-projects: read|write|none
+      repository-projects: read
+      # security-events: read|write|none
+      security-events: none
+      # statuses: read|write|none
+      statuses: none
+    steps:
+
+      - name: "Checkout"
+        uses: actions/checkout@v4
+
+      - name: "Prepare dependencies for TYPO3 v${{ matrix.typo3 }}"
+        run: "Build/Scripts/runTests.sh -t ${{ matrix.typo3 }} -p ${{ matrix.php-version }} -s composerUpdate"
+
+      - name: "functional with SQLite"
+        run: "Build/Scripts/runTests.sh -t ${{ matrix.typo3 }} -p ${{ matrix.php-version }} -d sqlite -s functional"
+
+      - name: "functional with MySQL 8.0 mysqli"
+        run: "Build/Scripts/runTests.sh -t ${{ matrix.typo3 }} -p ${{ matrix.php-version }} -d mysql -i 8.0 -a mysqli -s functional"
+
+      - name: "functional with MySQL 8.0 pdo_mysql"
+        run: "Build/Scripts/runTests.sh -t ${{ matrix.typo3 }} -p ${{ matrix.php-version }} -d mysql -i 8.0 -a pdo_mysql -s functional"
+
+      - name: "functional with MariaDB 10.4 mysqli"
+        run: "Build/Scripts/runTests.sh -t ${{ matrix.typo3 }} -p ${{ matrix.php-version }} -d mariadb -i 10.4 -a mysqli -s functional"
+
+      - name: "functional with MariaDB 10.6 pdo_mysql"
+        run: "Build/Scripts/runTests.sh -t ${{ matrix.typo3 }} -p ${{ matrix.php-version }} -d mariadb -i 10.6 -a pdo_mysql -s functional"
+
+      - name: "functional with Postgres 10"
+        run: "Build/Scripts/runTests.sh -t ${{ matrix.typo3 }} -p ${{ matrix.php-version }} -d postgres -i 10 -s functional"

--- a/Tests/Functional/ExtensionLoadedTest.php
+++ b/Tests/Functional/ExtensionLoadedTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WebVision\WvFileCleanup\Tests\Functional;
+
+use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
+use WebVision\WvFileCleanup\Tests\Functional\Fixtures\Functional\AbstractFunctionalTestCase;
+
+/**
+ * @internal
+ */
+final class ExtensionLoadedTest extends AbstractFunctionalTestCase
+{
+    private const ADDITIONAL_EXTENSIONS_REQUIRED_TO_BE_LOADED = [
+        'backend' => 'typo3/cms-backend',
+        'core' => 'typo3/cms-core',
+        'extbase' => 'typo3/cms-extbase',
+        'filelist' => 'typo3/cms-filelist',
+        'fluid' => 'typo3/cms-fluid',
+        'frontend' => 'typo3/cms-frontend',
+        'install' => 'typo3/cms-install',
+    ];
+
+    /**
+     * @test
+     */
+    public function extensionManagementUtilityIsLoadedByExtensionKeyReturnsTrue(): void
+    {
+        $this->assertTrue(ExtensionManagementUtility::isLoaded('wv_file_cleanup'));
+    }
+
+    /**
+     * @test
+     */
+    public function extensionManagementUtilityIsLoadedByComposerPackageNameReturnsTrue(): void
+    {
+        $this->assertTrue(ExtensionManagementUtility::isLoaded('web-vision/wv_file_cleanup'));
+    }
+
+    public static function additionalExtensionRequiredToBeLoadedInTest(): array
+    {
+        $return = [];
+        foreach (self::ADDITIONAL_EXTENSIONS_REQUIRED_TO_BE_LOADED as $extensionKey => $composerPackageName) {
+            $return[] = ['identifier' => $extensionKey];
+            $return[] = ['identifier' => $composerPackageName];
+        }
+        return $return;
+    }
+
+    /**
+     * @test
+     * @dataProvider additionalExtensionRequiredToBeLoadedInTest
+     */
+    public function ensureDependingExtensionsIsLoadedEitherByExtensionKeyOrComposerPackageName(string $identifier): void
+    {
+        $this->assertTrue(ExtensionManagementUtility::isLoaded($identifier));
+    }
+}

--- a/Tests/Functional/Fixtures/Functional/AbstractFunctionalTestCase.php
+++ b/Tests/Functional/Fixtures/Functional/AbstractFunctionalTestCase.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WebVision\WvFileCleanup\Tests\Functional\Fixtures\Functional;
+
+use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
+
+/**
+ * @internal
+ */
+abstract class AbstractFunctionalTestCase extends FunctionalTestCase
+{
+    /**
+     * @var string[]
+     */
+    protected array $coreExtensionsToLoad = [
+        'typo3/cms-install',
+        'typo3/cms-filelist',
+    ];
+
+    /**
+     * @var string[]
+     */
+    protected array $testExtensionsToLoad = [
+        'web-vision/wv_file_cleanup',
+    ];
+
+    /**
+     * These two internal variable track if the given test is the first test of
+     * that test case. This variable is set to current calling test case class.
+     * Consecutive tests then optimize and do not create a full
+     * database structure again but instead just truncate all tables which
+     * is much quicker.
+     */
+    private static string $currentTestCaseClass = '';
+    private bool $isFirstTest = true;
+
+    /**
+     * @before {@see self::setUp()}
+     */
+    protected function beforeSetUp(): void
+    {
+        $this->handleIsFirstTest();
+        $this->handleAdditionalExtensionsToLoad();
+    }
+
+    protected function handleIsFirstTest(): void
+    {
+        // See if we're the first test of this test case.
+        $currentTestCaseClass = static::class;
+        if (self::$currentTestCaseClass !== $currentTestCaseClass) {
+            self::$currentTestCaseClass = $currentTestCaseClass;
+        } else {
+            $this->isFirstTest = false;
+        }
+    }
+
+    protected function handleAdditionalExtensionsToLoad(): void
+    {
+        if ($this->isFirstTest) {
+            $this->coreExtensionsToLoad = $this->modifyCoreExtensionToLoad($this->coreExtensionsToLoad);
+            $this->testExtensionsToLoad = $this->modifyTestExtensionToLoad($this->testExtensionsToLoad);
+        }
+    }
+
+    /**
+     * Only called before first test setup. Changing extension between tests of the same TestCase is not supported.
+     *
+     * @param string[] $coreExtensionsToLoad
+     * @return string[]
+     */
+    protected function modifyCoreExtensionToLoad(array $coreExtensionsToLoad): array
+    {
+        return $coreExtensionsToLoad;
+    }
+
+    /**
+     * Only called before first test setup. Changing extension between tests of the same TestCase is not supported.
+     *
+     * @param string[] $testExtensionsToLoad
+     * @return string[]
+     */
+    protected function modifyTestExtensionToLoad(array $testExtensionsToLoad): array
+    {
+        return $testExtensionsToLoad;
+    }
+
+    final protected function isFirstTest(): bool
+    {
+        return $this->isFirstTest;
+    }
+}


### PR DESCRIPTION
This changes adds the `ExtensionLoadedTest` as first
test along with a `AbstractFunctionalTestCase` class
to test basic things without testing extension code
directly, for example:

* Ensure that using `AbstractFunctionalTestCase` loads the
  extension itself and the TYPO3 instance can find it using
  the `EXTENSION_KEY` and `COMPOSER_PACKAGE_NAME` declared
  in the root `composer.json` of the extension.

* Bootstraping extension with the instance already checks for
  derecated api or other deprecation including automatic TCA
  migration emitting `E_USER_DEPRECATED` by the for. It also
  reveales related issues directly like `Services.yaml` issues.

Beside acting as a first test, this test provides a simple base
test for the abstract testcase class and basic bootstrap related
issues helping on updates to use it as single test, as it may be
harder to find systematic issues with a later complete test suite.

Used command(s):

```bash
Build/Scripts/runTests.sh -p 7.4 -t 11 -s composerUpdate \
&& Build/Scripts/runTests.sh -p 7.4 -t 11 -s cgl
```
