### PR TITLE
[BUGFIX] Mitigate deprecated extbase `ViewInterface`

### DIFF
--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -617,7 +617,7 @@ case ${TEST_SUITE} in
         ;;
     phpstanGenerateBaseline)
         PHPSTAN_CONFIG_FILE="Build/phpstan/core${CORE_VERSION}/phpstan.neon"
-        COMMAND=(php -dxdebug.mode=off .Build/bin/phpstan analyse -c ${PHPSTAN_CONFIG_FILE} --no-progress --no-interaction --memory-limit 4G --allow-empty-baseline --generate-baseline=Build/phpstan/Core${CORE_VERSION}/phpstan-baseline.neon)
+        COMMAND=(php -dxdebug.mode=off .Build/bin/phpstan analyse -c ${PHPSTAN_CONFIG_FILE} --no-progress --no-interaction --memory-limit 4G --allow-empty-baseline --generate-baseline=Build/phpstan/core${CORE_VERSION}/phpstan-baseline.neon)
         ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name phpstan-baseline-${SUFFIX} -e COMPOSER_CACHE_DIR=.Build/.cache/composer -e COMPOSER_ROOT_VERSION=${COMPOSER_ROOT_VERSION} ${IMAGE_PHP} "${COMMAND[@]}"
         SUITE_EXIT_CODE=$?
         ;;

--- a/Build/phpstan/core11/phpstan-baseline.neon
+++ b/Build/phpstan/core11/phpstan-baseline.neon
@@ -146,11 +146,6 @@ parameters:
 			path: ../../../Classes/FileFacade.php
 
 		-
-			message: "#^Parameter \\#1 \\$function of function call_user_func_array expects callable\\(\\)\\: mixed, array\\{TYPO3\\\\CMS\\\\Core\\\\Resource\\\\FileInterface, string\\} given\\.$#"
-			count: 1
-			path: ../../../Classes/FileFacade.php
-
-		-
 			message: "#^Property WebVision\\\\WvFileCleanup\\\\FileFacade\\:\\:\\$databaseConnection has no type specified\\.$#"
 			count: 1
 			path: ../../../Classes/FileFacade.php

--- a/Build/phpstan/core12/phpstan-baseline.neon
+++ b/Build/phpstan/core12/phpstan-baseline.neon
@@ -66,6 +66,11 @@ parameters:
 			path: ../../../Classes/Controller/CleanupController.php
 
 		-
+			message: "#^Method WebVision\\\\WvFileCleanup\\\\Controller\\\\CleanupController\\:\\:initializeView\\(\\) has parameter \\$view with no type specified\\.$#"
+			count: 1
+			path: ../../../Classes/Controller/CleanupController.php
+
+		-
 			message: "#^PHPDoc tag @var has invalid value \\(\\$resourceFactory ResourceFactory \\*\\)\\: Unexpected token \"\\$resourceFactory\", expected type at offset 9$#"
 			count: 2
 			path: ../../../Classes/Controller/CleanupController.php
@@ -82,11 +87,6 @@ parameters:
 
 		-
 			message: "#^Parameter \\#2 \\$replace of function str_replace expects array\\|string, int\\<1, max\\> given\\.$#"
-			count: 1
-			path: ../../../Classes/Controller/CleanupController.php
-
-		-
-			message: "#^Parameter \\$view of method WebVision\\\\WvFileCleanup\\\\Controller\\\\CleanupController\\:\\:initializeView\\(\\) has invalid type TYPO3\\\\CMS\\\\Extbase\\\\Mvc\\\\View\\\\ViewInterface\\.$#"
 			count: 1
 			path: ../../../Classes/Controller/CleanupController.php
 
@@ -157,11 +157,6 @@ parameters:
 
 		-
 			message: "#^PHPDoc tag @var has invalid value \\(\\)\\: Unexpected token \"\\\\n     \", expected type at offset 34$#"
-			count: 1
-			path: ../../../Classes/FileFacade.php
-
-		-
-			message: "#^Parameter \\#1 \\$callback of function call_user_func_array expects callable\\(\\)\\: mixed, array\\{TYPO3\\\\CMS\\\\Core\\\\Resource\\\\FileInterface, string\\} given\\.$#"
 			count: 1
 			path: ../../../Classes/FileFacade.php
 

--- a/Classes/Controller/CleanupController.php
+++ b/Classes/Controller/CleanupController.php
@@ -25,7 +25,6 @@ use TYPO3\CMS\Core\Resource\ResourceFactory;
 use TYPO3\CMS\Core\Resource\ResourceStorage;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
-use TYPO3\CMS\Extbase\Mvc\View\ViewInterface;
 use WebVision\WvFileCleanup\Domain\Repository\FileRepository;
 
 /**
@@ -64,7 +63,11 @@ class CleanupController extends ActionController
         $this->moduleTemplate = $this->moduleTemplateFactory->create($this->request);
     }
 
-    public function initializeView(ViewInterface $view): void
+    /**
+     * Note that `$view` does not have native type declaration by intention to follow the recommended migration path for
+     * https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/11.5/Deprecation-95222-ExtbaseViewInterface.html.
+     */
+    public function initializeView($view): void
     {
         $this->pageRenderer->loadRequireJsModule('TYPO3/CMS/Backend/ContextMenu');
         $this->pageRenderer->loadRequireJsModule('TYPO3/CMS/WvFileCleanup/Cleanup');

--- a/Classes/FileFacade.php
+++ b/Classes/FileFacade.php
@@ -287,8 +287,9 @@ class FileFacade
      */
     public function __call($method, $arguments)
     {
-        if (is_callable([$this->resource, $method])) {
-            return call_user_func_array([$this->resource, $method], $arguments);
+        $resourceMethod = [$this->resource, $method];
+        if (is_callable($resourceMethod)) {
+            return call_user_func_array($resourceMethod, $arguments);
         }
 
         return null;


### PR DESCRIPTION
TYPO3 v11.5 started streamlining the view implementation,
which included deprecating the extbase `ViewInterface`.
Extensions supporting two TYPO3 core version need to take
care and the migration path for controllers overriding the
`initialzeView` method is stated in the changelog [1].

This change follows the recommended migration path and
removes the deprecated interface as method native type
declarion for the `$view` argument, avoiding in TYPO3
v12 the exception

  TYPO3\CMS\Extbase\Reflection\Exception\UnknownClassException
  Class "TYPO3\CMS\Extbase\Mvc\View\ViewInterface" does not exist.
  Reflection failed.

while still making required adjustments. We need to
add one error to the TYPO3 v12 phpstan baseline as
the error is not reported in TYPO3 v11 and using the
`phpstan-ignore` annotation does not work.

Dispatching a callable is slightly modified within
`FileFacade`, moving the callable array into local
variable first to allow phpstan properly deal with
it. That allows us to remove error pattern ignore
from the baseline instead of recreating it with a
changed message.

On top, a small typo (casing) in `runTests.sh` is
fixed along the way to write the updated baselines
to the correct paths.

Used command(s):

```shell
Build/Scripts/runTests.sh -p 8.1 -t 11 -s phpstanGenerateBaseline && \
Build/Scripts/runTests.sh -p 8.2 -t 12 -s phpstanGenerateBaseline
```
[1] https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/11.5/Deprecation-95222-ExtbaseViewInterface.html

Resolves: #22
