### PR TITLE
[TASK] Allow insecure composer dependencies versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,10 @@
             "typo3/class-alias-loader": true,
             "sbuerk/typo3-cmscomposerinstallers-testingframework-bridge": true
         },
-        "sort-packages": true
+        "sort-packages": true,
+        "audit": {
+            "block-insecure": false
+        }
     },
     "minimum-stability": "dev",
     "prefer-stable": true


### PR DESCRIPTION
Since `composer 2.9.0` security advisory checks for
dependencies are enabled by default, which does not
play well with extension development not wanting to
enforce consumer to update and keep the decision in
there hands, for example projects.

To unblock public extension development and allowing
to run pipelines with older versions, the available
composer configuration `audit.block-insecure` is now
set to false.

> [!IMPORTANT]
> This has no direct security impact but using latest
> security versions of depending packages is considered
> best-practice and recommened.

Used command(s):

```shell
composer config "audit"."block-insecure" false
```
