### PR TITLE
[BUGFIX] Respect moved and renamed language labels

### DIFF
--- a/Classes/Utility/LanguageLabels.php
+++ b/Classes/Utility/LanguageLabels.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WebVision\WvFileCleanup\Utility;
+
+use TYPO3\CMS\Core\Information\Typo3Version;
+
+/**
+ * Provides TYPO3 version related label definitions to be
+ * TYPO3 version agnostic.
+ *
+ * @internal for EXT:wv_file_cleanup internal usage and not part of public API.
+ */
+final class LanguageLabels
+{
+    private Typo3Version $typo3Version;
+
+    public function __construct(
+        Typo3Version $typo3Version
+    ) {
+        $this->typo3Version = $typo3Version;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getControllerLanguageLabelFiles(): array
+    {
+        return [
+            'EXT:core/Resources/Private/Language/locallang_core.xlf',
+            'EXT:core/Resources/Private/Language/locallang_misc.xlf',
+            'EXT:filelist/Resources/Private/Language/locallang_mod_file_list.xlf',
+            'EXT:wv_file_cleanup/Resources/Private/Language/locallang_mod_cleanup.xlf',
+        ];
+    }
+
+    public function getDisplayThumbsLabel(): string
+    {
+        if ($this->typo3Version->getMajorVersion() < 12) {
+            // 'LLL:EXT:filelist/Resources/Private/Language/locallang_mod_file_list.xlf:displayThumbs'
+            return 'displayThumbs';
+        }
+        // LLL:EXT:core/Resources/Private/Language/locallang_core.xlf:labels.view.showThumbnails'
+        return 'labels.view.showThumbnails';
+    }
+
+    public function searchFoldersRecursiveLabel(): string
+    {
+        // 'LLL:EXT:wv_file_cleanup/Resources/Private/Language/locallang_mod_cleanup.xlf:search_folders_recursive'
+        return 'search_folders_recursive';
+    }
+
+    public function oneLevelUpLabel(): string
+    {
+        // 'LLL:EXT:core/Resources/Private/Language/locallang_core.xlf:labels.upOneLevel'
+        return 'labels.upOneLevel';
+    }
+
+    public function missingFolderPermissionsMessage(): string
+    {
+        //  'LLL:EXT:filelist/Resources/Private/Language/locallang_mod_file_list.xlf:missingFolderPermissionsMessage'
+        return 'missingFolderPermissionsMessage';
+    }
+
+    public function missingFolderPermissionsTitle(): string
+    {
+        // 'LLL:EXT:filelist/Resources/Private/Language/locallang_mod_file_list.xlf:missingFolderPermissionsTitle'
+        return 'missingFolderPermissionsTitle';
+    }
+
+    public function folderNotFoundMessage(): string
+    {
+        // 'LLL:EXT:filelist/Resources/Private/Language/locallang_mod_file_list.xlf:folderNotFoundMessage'
+        return 'folderNotFoundMessage';
+    }
+
+    public function folderNotFoundTitle(): string
+    {
+        // 'LLL:EXT:filelist/Resources/Private/Language/locallang_mod_file_list.xlf:folderNotFoundTitle'
+        return 'folderNotFoundTitle';
+    }
+}

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -27,4 +27,3 @@ services:
 
   WebVision\WvFileCleanup\Controller\CleanupController:
     tags: [ 'backend.controller' ]
-


### PR DESCRIPTION
TYPO3 v12.1 reworked some views and moved language labels
and rename some of them to match the reworked views. [1]

This change introduces a internal language label handling
class to reflect TYPO3 version related changes as a minor
change. In the long term the backend view needs to aligned
when TYPO3 v11 support is dropped and language handling
should be reworked to use foll `LLL:EXT:` syntax instead.

[1] https://review.typo3.org/c/Packages/TYPO3.CMS/+/76602

**Before:**

<img width="584" height="231" alt="image" src="https://github.com/user-attachments/assets/7199cafd-4efe-4fd2-8508-528fb96f2dcc" />


**After:**

<img width="544" height="226" alt="image" src="https://github.com/user-attachments/assets/caca5d9a-9c91-4e93-a2d0-0bf154fb9d74" />

